### PR TITLE
Add SplitMate React Native skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # PandaETL Project
+
+This repository now includes **SplitMate**, a simple React Native app that helps friends split restaurant bills using receipt images. The original ETL components remain in `src/`.
+
+See `splitmate/README.md` for instructions on running the mobile app.

--- a/splitmate/App.js
+++ b/splitmate/App.js
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { SafeAreaView, Button, Image, ScrollView, Text, TextInput, View, TouchableOpacity } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import Tesseract from 'tesseract.js';
+
+export default function App() {
+  const [image, setImage] = useState(null);
+  const [items, setItems] = useState([]); // {name: '', price: '', friends: []}
+  const [friends, setFriends] = useState([]); // [string]
+  const [newFriend, setNewFriend] = useState('');
+  const [tip, setTip] = useState('0');
+
+  const pickImage = async () => {
+    let result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, allowsEditing: false });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      setImage(uri);
+      const ocr = await Tesseract.recognize(uri, 'eng');
+      const text = ocr.data.text;
+      const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+      const parsed = lines.map(l => {
+        const m = l.match(/(.+)\s+(\d+[\.\d]*)$/);
+        if (m) return { name: m[1], price: m[2], friends: [] };
+        return null;
+      }).filter(x => x);
+      setItems(parsed);
+    }
+  };
+
+  const addFriend = () => {
+    if (newFriend) {
+      setFriends([...friends, newFriend]);
+      setNewFriend('');
+    }
+  };
+
+  const toggleItemFriend = (itemIndex, friend) => {
+    const updated = [...items];
+    const idx = updated[itemIndex].friends.indexOf(friend);
+    if (idx >= 0) {
+      updated[itemIndex].friends.splice(idx, 1);
+    } else {
+      updated[itemIndex].friends.push(friend);
+    }
+    setItems(updated);
+  };
+
+  const totals = () => {
+    const friendTotals = {};
+    friends.forEach(f => friendTotals[f] = 0);
+    items.forEach(item => {
+      if (item.friends.length === 0) return;
+      const share = parseFloat(item.price) / item.friends.length;
+      item.friends.forEach(f => friendTotals[f] += share);
+    });
+    const tipPct = parseFloat(tip) / 100;
+    friends.forEach(f => friendTotals[f] += friendTotals[f] * tipPct);
+    return friendTotals;
+  };
+
+  return (
+    <SafeAreaView style={{flex:1, padding:20}}>
+      <ScrollView>
+        <Button title="Pick Receipt Image" onPress={pickImage} />
+        {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+        {items.map((item, idx) => (
+          <View key={idx} style={{ marginVertical: 5 }}>
+            <Text>{item.name} - ${item.price}</Text>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+              {friends.map(f => (
+                <TouchableOpacity key={f} onPress={() => toggleItemFriend(idx, f)} style={{ margin: 2, padding: 4, backgroundColor: item.friends.includes(f) ? '#84e' : '#ccc' }}>
+                  <Text>{f}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        ))}
+        <View style={{ flexDirection: 'row', marginVertical: 10 }}>
+          <TextInput style={{ borderWidth:1, flex:1, marginRight:5, padding:5 }} placeholder="Add friend" value={newFriend} onChangeText={setNewFriend} />
+          <Button title="Add" onPress={addFriend} />
+        </View>
+        <View style={{ flexDirection:'row', marginVertical:5 }}>
+          <Text>Tip %: </Text>
+          <TextInput style={{ borderWidth:1, flex:1, padding:5 }} keyboardType="numeric" value={tip} onChangeText={setTip} />
+        </View>
+        <Text style={{fontSize:18, marginTop:10}}>Totals:</Text>
+        {friends.map(f => (
+          <Text key={f}>{f}: ${totals()[f].toFixed(2)}</Text>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/splitmate/README.md
+++ b/splitmate/README.md
@@ -1,0 +1,27 @@
+# SplitMate
+
+SplitMate is a simple React Native app built with Expo for splitting restaurant bills with friends. Upload a receipt image, assign dishes to friends, and see what everyone owes.
+
+## Getting Started
+1. Install [Expo CLI](https://docs.expo.dev/get-started/installation/) if you don't have it:
+```
+npm install -g expo-cli
+```
+2. Install dependencies:
+```
+cd splitmate
+npm install
+```
+3. Run the app:
+```
+expo start
+```
+The Expo dashboard will let you run the app on an emulator or a mobile device using the Expo Go client.
+
+## Features
+- Upload a photo of a receipt.
+- OCR processing with `tesseract.js` to detect item names and prices.
+- Add friends and assign them to receipt items.
+- Automatic calculation of each person's share with adjustable tip percentage.
+
+This app is a lightweight demo and can be extended with more features like syncing with payment services or exporting results.

--- a/splitmate/package.json
+++ b/splitmate/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "splitmate",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "expo-image-picker": "^15.0.2",
+    "tesseract.js": "^4.0.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new mobile app `SplitMate`
- implement React Native receipt OCR and item splitting logic in App.js
- document usage in splitmate/README.md
- update root README with SplitMate info

## Testing
- `npm install --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_684084ecdd18832aa15741dd78c89ae7